### PR TITLE
Fix python command in the documentation

### DIFF
--- a/Firmware_Flashing_Guide.md
+++ b/Firmware_Flashing_Guide.md
@@ -29,13 +29,13 @@ python -m pip install esptool
 Erase flash entirely to ensure nothing will go wrong
 
 ```shell
-python esptool.py --chip esp32 --baud 460800 erase_flash
+python -m esptool --chip esp32 --baud 460800 erase_flash
 ```
 
 Install the firmware
 
 ```shell
-python esptool.py --chip esp32 --baud 460800 write_flash -z 0x1000 esp32-full.img
+python -m esptool --chip esp32 --baud 460800 write_flash -z 0x1000 esp32-full.img
 ```
 
 Subsequent updates should be done via the OTA mechanism.
@@ -51,12 +51,6 @@ While this procedure is not supposed to overwrite your existing configuration, w
 ### Using RFLink serial commands
 
 ...TODO...
-
-### Using Esptool
-
-```shell
-python.exe esptool.py --chip esp32 --baud 460800 write_flash -z 0x10000 esp32-firmware-OTA.bin
-```
 
 ### Using Espressif's official tool
 

--- a/doc/sonoff_rf_bridge.md
+++ b/doc/sonoff_rf_bridge.md
@@ -39,19 +39,19 @@ python -m pip install esptool
 Create a backup of the Sonoff firmware:
 
 ```shell
-python esptool.py --baud 460800 read_flash 0x00000 0x100000 Backup_SonoffRFBridge.bin
+python -m esptool --baud 460800 read_flash 0x00000 0x100000 Backup_SonoffRFBridge.bin
 ```
 
 Erase firmware:
 
 ```shell
-python esptool.py --baud 460800 erase_flash
+python -m esptool --baud 460800 erase_flash
 ```
 
 Flash the RFLink firmware:
 
 ```shell
-python esptool.py --baud 460800 write_flash -fs 1MB -fm dout 0x0 sonoff_bridge-firmware.bin
+python -m esptool --baud 460800 write_flash -fs 1MB -fm dout 0x0 sonoff_bridge-firmware.bin
 ```
 
 You can then use either the [CLI](/CLI_Reference_Guide.md) connected via the UART to configure the RF bridge or the Config Portal.


### PR DESCRIPTION
* Command `python esptool.py ...` fails with `can't open file 'esptool.py'` error.