### PR TITLE
add compatiblity to RFLink 1.48, fix build errors on Arduino IDE 1.8.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ RFLink/*.ino
 cmake-build-*
 CMakeLists.txt
 CMakeListsPrivate.txt
+*.bak

--- a/RFLink/11_Config.cpp
+++ b/RFLink/11_Config.cpp
@@ -93,6 +93,7 @@ namespace RFLink
 
     void printFile()
     {
+      #ifdef DEBUG
       // Open file for reading
       Serial.println(F("Now dumping JSON file content:"));
       File file = LittleFS.open(configFileName, "r");
@@ -111,6 +112,7 @@ namespace RFLink
 
       // Close the file
       file.close();
+      #endif
     }
 
     ConfigItem *findConfigItem(const char *name, SectionId section)
@@ -135,7 +137,9 @@ namespace RFLink
 
     void setup()
     {
-      Serial.print(F("Loading persistent filesystem... "));
+      #ifdef DEBUG
+        Serial.print(F("Loading persistent filesystem... "));
+      #endif
 
       #ifdef ESP32
       if (!LittleFS.begin(true))
@@ -146,14 +150,20 @@ namespace RFLink
         Serial.println(F(" FAILED!!"));
         return;
       }
-      Serial.print(F("OK. "));
+      #ifdef DEBUG
+        Serial.print(F("OK. "));
+      #endif
 
 #ifdef ESP32
-      Serial.printf_P(PSTR("File system usage: %u/%uKB.\r\n"), LittleFS.usedBytes() / 1024, LittleFS.totalBytes() / 1024);
+      #ifdef DEBUG
+        Serial.printf_P(PSTR("File system usage: %u/%uKB.\r\n"), LittleFS.usedBytes() / 1024, LittleFS.totalBytes() / 1024);
+      #endif
 #else // this is ESP8266
       FSInfo info;
       LittleFS.info(info);
-      Serial.printf_P(PSTR("File system usage: %u/%uKB.\r\n"), info.usedBytes / 1024, info.totalBytes / 1024);
+      #ifdef DEBUG
+        Serial.printf_P(PSTR("File system usage: %u/%uKB.\r\n"), info.usedBytes / 1024, info.totalBytes / 1024);
+      #endif
 #endif
 
 
@@ -194,7 +204,9 @@ namespace RFLink
       //sprintf(tmp, "Counted %i config items in total", countConfigItems);
       //Serial.println(tmp);
 
-      Serial.printf(PSTR("Now opening JSON config file '%s'\r\n"), configFileName);
+      #ifdef DEBUG
+        Serial.printf(PSTR("Now opening JSON config file '%s'\r\n"), configFileName);
+      #endif
 
       File file = LittleFS.open(configFileName, "r");
       DeserializationError error = deserializeJson(doc, file);
@@ -202,7 +214,9 @@ namespace RFLink
         Serial.println(F("Failed to read file, using default configuration"));
       file.close();
 
-      Serial.printf_P(PSTR("JSON file mem usage: %u / %u\r\n"), doc.memoryUsage(), doc.memoryPool().capacity());
+      #ifdef DEBUG
+        Serial.printf_P(PSTR("JSON file mem usage: %u / %u\r\n"), doc.memoryUsage(), doc.memoryPool().capacity());
+      #endif
 
       bool fileHasChanged = false;
 

--- a/RFLink/13_OTA.cpp
+++ b/RFLink/13_OTA.cpp
@@ -2,6 +2,8 @@
 
 #include "RFLink.h"
 
+#ifndef RFLINK_PORTAL_DISABLED
+
 #ifdef ESP32
 #include <HTTPClient.h>
 #include <HTTPUpdate.h>
@@ -163,3 +165,5 @@ namespace RFLink
 
   } // end of AutoOTA namespace
 } // end of RFLink namespace
+
+#endif // RFLINK_PORTAL_DISABLED

--- a/RFLink/1_Radio.cpp
+++ b/RFLink/1_Radio.cpp
@@ -503,78 +503,106 @@ namespace RFLink { namespace Radio  {
     {
       if (pins::RX_PMOS != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_PMOS :\t"));
-        Serial.println(GPIO2String(pins::RX_PMOS));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_PMOS :\t"));
+          Serial.println(GPIO2String(pins::RX_PMOS));
+        #endif
       }
       if (pins::RX_NMOS != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_NMOS :\t"));
-        Serial.println(GPIO2String(pins::RX_NMOS));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_NMOS :\t"));
+          Serial.println(GPIO2String(pins::RX_NMOS));
+        #endif
       }
       if (pins::RX_VCC != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_VCC :\t"));
-        Serial.println(GPIO2String(pins::RX_VCC));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_VCC :\t"));
+          Serial.println(GPIO2String(pins::RX_VCC));
+        #endif
       }
       if (pins::RX_GND != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_GND :\t"));
-        Serial.println(GPIO2String(pins::RX_GND));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_GND :\t"));
+          Serial.println(GPIO2String(pins::RX_GND));
+        #endif
       }
       if (pins::RX_NA != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_NA :\t"));
-        Serial.println(GPIO2String(pins::RX_NA));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_NA :\t"));
+          Serial.println(GPIO2String(pins::RX_NA));
+        #endif
       }
       if (pins::RX_DATA != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_DATA :\t"));
-        Serial.print(GPIO2String(pins::RX_DATA));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_DATA :\t"));
+          Serial.print(GPIO2String(pins::RX_DATA));
         if (pins::PULLUP_RX_DATA)
           Serial.println(F(" (Pullup enabled)"));
         else
           Serial.println();
+        #endif
       }
       if (pins::RX_CS != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_CS :\t"));
-        Serial.println(GPIO2String(pins::RX_CS));
+        #ifdef DEBUG
+          Serial.print(F("Radio pin RF_RX_CS :\t"));
+          Serial.println(GPIO2String(pins::RX_CS));
+        #endif
       }
       if (pins::RX_RESET != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_RX_RESET :\t"));
-        Serial.println(GPIO2String(pins::RX_RESET));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_RX_RESET :\t"));
+          Serial.println(GPIO2String(pins::RX_RESET));
+        #endif
       }
       //
       if (pins::TX_PMOS != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_TX_PMOS :\t"));
-        Serial.println(GPIO2String(pins::TX_PMOS));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_TX_PMOS :\t"));
+          Serial.println(GPIO2String(pins::TX_PMOS));
+        #endif
       }
       if (pins::TX_NMOS != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_TX_NMOS :\t"));
-        Serial.println(GPIO2String(pins::TX_NMOS));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_TX_NMOS :\t"));
+          Serial.println(GPIO2String(pins::TX_NMOS));
+        #endif
       }
       if (pins::TX_VCC != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_TX_VCC :\t"));
-        Serial.println(GPIO2String(pins::TX_VCC));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_TX_VCC :\t"));
+          Serial.println(GPIO2String(pins::TX_VCC));
+        #endif
       }
       if (pins::TX_GND != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_TX_GND :\t"));
-        Serial.println(GPIO2String(pins::TX_GND));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_TX_GND :\t"));
+          Serial.println(GPIO2String(pins::TX_GND));
+        #endif
       }
       if (pins::TX_DATA != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_TX_DATA :\t"));
-        Serial.println(GPIO2String(pins::TX_DATA));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_TX_DATA :\t"));
+          Serial.println(GPIO2String(pins::TX_DATA));
+        #endif
       }
       if (pins::TX_NA != NOT_A_PIN)
       {
-        Serial.print(F("Radio pin RF_TX_NA :\t"));
-        Serial.println(GPIO2String(pins::TX_NA));
+        #ifdef DEBUG 
+          Serial.print(F("Radio pin RF_TX_NA :\t"));
+          Serial.println(GPIO2String(pins::TX_NA));
+        #endif
       }
     }
 #endif // ESP8266 || ESP32
@@ -960,7 +988,9 @@ namespace RFLink { namespace Radio  {
         sprintf(printBuf, PSTR("Switching from Radio hardware '%s' to '%s'"), hardwareNames[hardware], hardwareNames[newHardware]);
         RFLink::sendRawPrint(printBuf, true);
       } else {
-        sprintf(printBuf, PSTR("Now trying to initialize hardware '%s'"), hardwareNames[hardware]);
+        #ifdef DEBUG
+          sprintf(printBuf, PSTR("Now trying to initialize hardware '%s'"), hardwareNames[hardware]);
+        #endif
         RFLink::sendRawPrint(printBuf, true);
       }
 
@@ -994,7 +1024,9 @@ namespace RFLink { namespace Radio  {
       if(!success) {
         RFLink::sendRawPrint(F("Hardware failed to initialize, we will retry later!"), true);
       } else {
-        RFLink::sendRawPrint(F("Hardware initialization was successful!"), true);
+        #ifdef DEBUG
+          RFLink::sendRawPrint(F("Hardware initialization was successful!"), true);
+        #endif
         hardwareProperlyInitialized = true;
         Radio::set_Radio_mode(Radio::current_State, true);
       }

--- a/RFLink/2_Signal.cpp
+++ b/RFLink/2_Signal.cpp
@@ -194,7 +194,9 @@ namespace RFLink
       // Applying changes will happen in mainLoop()
       if (triggerChanges && changesDetected)
       {
-        Serial.println(F("Signal parameters have changed."));
+        #ifdef DEBUG
+          Serial.println(F("Signal parameters have changed."));
+        #endif
         if (params::async_mode_enabled && AsyncSignalScanner::isStopped())
         {
           AsyncSignalScanner::startScanning();
@@ -1185,7 +1187,9 @@ namespace RFLink
         runtime::appliedSlicer = newSlicer;
       }
 
-      sprintf_P(printBuf, PSTR("Applied slicer '%s'"), slicerIdToString(runtime::appliedSlicer));
+      #ifdef DEBUG
+        sprintf_P(printBuf, PSTR("Applied slicer '%s'"), slicerIdToString(runtime::appliedSlicer));
+      #endif
       sendRawPrint(printBuf, true);
 
       return true;

--- a/RFLink/Plugins/Plugin_009.c
+++ b/RFLink/Plugins/Plugin_009.c
@@ -288,7 +288,7 @@ boolean Plugin_009(byte function, const char *string)
 #endif //PLUGIN_009
 
 #ifdef PLUGIN_TX_009
-#include "1_Radio.h"
+#include "../1_Radio.h"
 void X10_Send(uint32_t address);
 
 boolean  PluginTX_009(byte function, const char *string)

--- a/RFLink/Plugins/Plugin_076.cpp
+++ b/RFLink/Plugins/Plugin_076.cpp
@@ -58,9 +58,9 @@ using namespace RFLink::Radio;
 #define PLUGIN_076_REPEAT_IGNORE_TIME_MS 1500
 
 #if defined(PLUGIN_076)
-#include "1_Radio.h"
-#include "2_Signal.h"
-#include "4_Display.h"
+#include "../1_Radio.h"
+#include "../2_Signal.h"
+#include "../4_Display.h"
 
 #if defined(DEBUG) || defined(RFLINK_DEBUG)
 #define PLUGIN_076_DEBUG
@@ -177,7 +177,7 @@ boolean Plugin_076(byte function, const char *string)
 
 #ifdef PLUGIN_TX_076
 
-#include "3_Serial.h"
+#include "../3_Serial.h"
 
 boolean  PluginTX_076(byte function, const char *string)
 {

--- a/RFLink/Plugins/Plugin_087.c
+++ b/RFLink/Plugins/Plugin_087.c
@@ -108,8 +108,8 @@ boolean Plugin_087(byte function, const char *string)
 
 #ifdef PLUGIN_TX_087
 
-#include "1_Radio.h"
-#include "2_Signal.h"
+#include "../1_Radio.h"
+#include "../2_Signal.h"
 
 boolean PluginTX_087(byte function, const char *string)
 {

--- a/RFLink/Plugins/_Plugin_Config_01.h
+++ b/RFLink/Plugins/_Plugin_Config_01.h
@@ -16,8 +16,8 @@
 #ifndef _RFLINK_PLUGIN_CONFIG_01_H_
 #define _RFLINK_PLUGIN_CONFIG_01_H_
 
-#include "2_Signal.h"
-#include "1_Radio.h"
+#include "../2_Signal.h"
+#include "../1_Radio.h"
 
 // ****************************************************************************************************************************************
 // Translation Plugin for oversized packets due to their breaks/pause being too short between packets

--- a/RFLink/RFLink.cpp
+++ b/RFLink/RFLink.cpp
@@ -74,24 +74,41 @@ namespace RFLink {
 
 #if (defined(ESP32) || defined(ESP8266))
       Serial.println(); // ESP "Garbage" message
-      Serial.print(F("Arduino IDE Version :\t"));
-      Serial.println(ARDUINO);
+      delay(1000);
+
+      #ifdef DEBUG 
+        Serial.print(F("Arduino IDE Version :\t")); 
+        Serial.println(ARDUINO); 
+      #endif
 #endif
 #ifdef ESP32
-      Serial.print(F("ESP SDK version:\t"));
-      Serial.println(ESP.getSdkVersion());
+      #ifdef DEBUG 
+        Serial.print(F("ESP SDK version:\t")); 
+        Serial.println(ESP.getSdkVersion()); 
+      #endif
 #endif
 #ifdef ESP8266
-      Serial.print(F("ESP CoreVersion :\t"));
-      Serial.println(ESP.getCoreVersion());
+      #ifdef DEBUG 
+        Serial.print(F("ESP CoreVersion :\t")); 
+        Serial.println(ESP.getCoreVersion()); 
+      #endif
 #endif // ESP8266
-      Serial.print(F("Sketch File :\t\t"));
-      Serial.println(F(__FILE__)); // "RFLink.ino" version is in 20;00 Message
-      Serial.println(F("Compiled on :\t\t" __DATE__ " at " __TIME__));
+      #ifdef DEBUG 
+        Serial.print(F("Sketch File :\t\t")); 
+        Serial.println(F(__FILE__)); // "RFLink.ino" version is in 20;00 Message 
+        Serial.println(F("Compiled on :\t\t" __DATE__ " at " __TIME__)); 
+      #endif
 
-      display_Header();
-      display_Splash();
-      display_Footer();
+      //compatiblity to old RFLink 1.48
+      display_Header(); 
+      display_Name(PSTR("RFLink Gateway"));
+      display_Footer(); 
+
+      #ifdef DEBUG 
+        display_Header(); 
+        DEBUG display_Splash(); 
+        DEBUG display_Footer(); 
+      #endif
 
 #ifdef SERIAL_ENABLED
       Serial.print(pbuffer);
@@ -180,7 +197,10 @@ namespace RFLink {
       }
 
       Radio::mainLoop();
+
+      #ifndef RFLINK_PORTAL_DISABLED
       OTA::mainLoop();
+      #endif
     }
 
     void sendMsgFromBuffer() {

--- a/RFLink/RFLink.h
+++ b/RFLink/RFLink.h
@@ -8,6 +8,9 @@
 #ifndef RFLink_h
 #define RFLink_h
 
+//bugfix to use 64-bit integers with ArduinoJson
+#define ARDUINOJSON_USE_LONG_LONG 1
+
 #include <ArduinoJson.h>
 #include <time.h>
 #include <sys/time.h>
@@ -27,8 +30,11 @@
 //#define RFLINK_AUTOOTA_ENABLED // if you want to the device to self-update at boot from a given URKL
                           // dont forget to set the URL in Crendentials.h
 
-//#define RFLINK_MQTT_DISABLED    // to disable MQTT entirely (not compiled at all)
-//#define RFLINK_PORTAL_DISABLED    // to disable Portal/Web UI
+//enable only serial messages
+#define RFLINK_MQTT_DISABLED    // to disable MQTT entirely (not compiled at all)
+#define RFLINK_PORTAL_DISABLED    // to disable Portal/Web UI
+#define RFLINK_NO_RADIOLIB_SUPPORT
+#define RFLINK_SERIAL2NET_DISABLED
 
 #if (defined(ESP32) || defined(ESP8266))
 // OLED display, 0.91" SSD1306 I2C


### PR DESCRIPTION
- modify serial output to ensure compatiblity to RFLink 1.48
- fix build errors on Arduino IDE 1.8.19 (add .ino, fix wrong includes, add ARDUINOJSON_USE_LONG_LONG for ArduinoJson)
- add option RFLINK_PORTAL_DISABLED to disable the portal